### PR TITLE
Add validated data storage feature for middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to express-yup-middleware will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New `storeValidatedData` option to store validated and typed objects in the request object
+- New `validatedDataKey` option to customize where validated data is stored in the request object
+
 ## [2.0.0] - 2023-12-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -303,6 +303,41 @@ const schemaValidator = {
 }
 ```
 
+## Accessing validated data in request handlers
+
+You can store the validated and typed objects in the request for use in your handlers:
+
+```ts
+const schemaValidator = {
+  schema: {
+    body: {
+      yupSchema: Yup.object().shape({
+        email: Yup.string().email().required(),
+        password: Yup.string().min(8).required(),
+      }),
+    },
+  },
+}
+
+app.post(
+  '/login',
+  expressYupMiddleware({
+    schemaValidator,
+    storeValidatedData: true, // Enable storing validated data
+    validatedDataKey: 'validated', // Optional: customize the property name (default is 'validated')
+  }),
+  (req, res) => {
+    // Access the validated data with proper types
+    const { email, password } = req.validated.body
+
+    // Your handler logic here
+    // ...
+  },
+)
+```
+
+This feature is particularly useful when working with TypeScript, as it gives you type-safe access to your validated data without having to call `validate()` again in your handler.
+
 ## Documentation
 
 - [CHANGELOG](CHANGELOG.md) - Details about each release

--- a/src/express-yup-middleware.ts
+++ b/src/express-yup-middleware.ts
@@ -14,6 +14,8 @@ export interface ExpressYupMiddlewareOptions {
   errorFormatter?: (errors: ValidationResult) => any
   continueOnError?: boolean
   customContextKey?: string
+  storeValidatedData?: boolean
+  validatedDataKey?: string
 }
 
 export const expressYupMiddleware =
@@ -24,13 +26,21 @@ export const expressYupMiddleware =
     errorFormatter,
     continueOnError = false,
     customContextKey,
+    storeValidatedData = false,
+    validatedDataKey = 'validated',
   }: ExpressYupMiddlewareOptions) =>
   async (req: Request, res: Response, next: NextFunction) => {
-    const errors = await validatePayload({
+    const { errors, validatedData } = await validatePayload({
       schemaValidator,
       payload: req,
       propertiesToValidate,
+      returnValidatedData: storeValidatedData,
     })
+
+    // Store validated data in request object if storeValidatedData is true
+    if (storeValidatedData && validatedData) {
+      req[validatedDataKey] = validatedData
+    }
 
     if (!errors) {
       return next()

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export {
   ValidationError,
   ValidationResult,
 } from './schema-validation-interface'
-export { validatePayload } from './schema-validator'
+export { ValidatePayloadResult, validatePayload } from './schema-validator'

--- a/src/validated-data-feature.spec.ts
+++ b/src/validated-data-feature.spec.ts
@@ -1,0 +1,236 @@
+import bodyParser from 'body-parser'
+import express, { Request, Response } from 'express'
+import request from 'supertest'
+import * as Yup from 'yup'
+
+import { expressYupMiddleware } from './express-yup-middleware'
+import { ExpressYupMiddlewareInterface } from './schema-validation-interface'
+
+const createAppWithPath = ({ path, middleware, method = 'get', handler = null }) => {
+  const app = express()
+
+  app.use(bodyParser.json())
+
+  app[method](path, middleware, handler || ((_req: Request, res: Response) => res.sendStatus(200)))
+
+  return app
+}
+
+describe('express-yup-middleware validated data feature', () => {
+  describe('when using the storeValidatedData option', () => {
+    it('should store validated data in req.validated by default', async () => {
+      // Arrange
+      const schemaValidator: ExpressYupMiddlewareInterface = {
+        schema: {
+          body: {
+            yupSchema: Yup.object().shape({
+              name: Yup.string().required(),
+              email: Yup.string().email().required(),
+            }),
+          },
+        },
+      }
+
+      let validatedDataFromRequest = null
+
+      const app = createAppWithPath({
+        path: '/test',
+        method: 'post',
+        middleware: expressYupMiddleware({
+          schemaValidator,
+          storeValidatedData: true,
+        }),
+        handler: (req: Request, res: Response) => {
+          validatedDataFromRequest = req['validated']
+          return res.json({ validatedData: validatedDataFromRequest })
+        },
+      })
+
+      // Act
+      const testData = { name: 'John Doe', email: 'john@example.com' }
+      const response = await request(app).post('/test').send(testData)
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(validatedDataFromRequest).toBeDefined()
+      expect(validatedDataFromRequest.body).toEqual(testData)
+    })
+
+    it('should use a custom key when validatedDataKey is provided', async () => {
+      // Arrange
+      const schemaValidator: ExpressYupMiddlewareInterface = {
+        schema: {
+          body: {
+            yupSchema: Yup.object().shape({
+              name: Yup.string().required(),
+              email: Yup.string().email().required(),
+            }),
+          },
+        },
+      }
+
+      let validatedDataFromRequest = null
+      const customKey = 'typedData'
+
+      const app = createAppWithPath({
+        path: '/test',
+        method: 'post',
+        middleware: expressYupMiddleware({
+          schemaValidator,
+          storeValidatedData: true,
+          validatedDataKey: customKey,
+        }),
+        handler: (req: Request, res: Response) => {
+          validatedDataFromRequest = req[customKey]
+          return res.json({ validatedData: validatedDataFromRequest })
+        },
+      })
+
+      // Act
+      const testData = { name: 'John Doe', email: 'john@example.com' }
+      const response = await request(app).post('/test').send(testData)
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(validatedDataFromRequest).toBeDefined()
+      expect(validatedDataFromRequest.body).toEqual(testData)
+    })
+
+    it('should validate multiple properties and store them separately', async () => {
+      // Arrange
+      const schemaValidator: ExpressYupMiddlewareInterface = {
+        schema: {
+          body: {
+            yupSchema: Yup.object().shape({
+              name: Yup.string().required(),
+            }),
+          },
+          query: {
+            yupSchema: Yup.object().shape({
+              filter: Yup.string().required(),
+            }),
+          },
+          params: {
+            yupSchema: Yup.object().shape({
+              id: Yup.string().required(),
+            }),
+          },
+        },
+      }
+
+      let validatedDataFromRequest = null
+
+      const app = createAppWithPath({
+        path: '/test/:id',
+        method: 'post',
+        middleware: expressYupMiddleware({
+          schemaValidator,
+          storeValidatedData: true,
+        }),
+        handler: (req: Request, res: Response) => {
+          validatedDataFromRequest = req['validated']
+          return res.json({ validatedData: validatedDataFromRequest })
+        },
+      })
+
+      // Act
+      const bodyData = { name: 'John Doe' }
+      const response = await request(app).post('/test/123').query({ filter: 'active' }).send(bodyData)
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(validatedDataFromRequest).toBeDefined()
+      expect(validatedDataFromRequest.body).toEqual(bodyData)
+      expect(validatedDataFromRequest.query).toEqual({ filter: 'active' })
+      expect(validatedDataFromRequest.params).toEqual({ id: '123' })
+    })
+
+    it('should not store validated data when storeValidatedData is false', async () => {
+      // Arrange
+      const schemaValidator: ExpressYupMiddlewareInterface = {
+        schema: {
+          body: {
+            yupSchema: Yup.object().shape({
+              name: Yup.string().required(),
+              email: Yup.string().email().required(),
+            }),
+          },
+        },
+      }
+
+      let validatedDataFromRequest = null
+
+      const app = createAppWithPath({
+        path: '/test',
+        method: 'post',
+        middleware: expressYupMiddleware({
+          schemaValidator,
+          storeValidatedData: false, // Explicitly set to false
+        }),
+        handler: (req: Request, res: Response) => {
+          validatedDataFromRequest = req['validated']
+          return res.json({ validatedData: validatedDataFromRequest })
+        },
+      })
+
+      // Act
+      const testData = { name: 'John Doe', email: 'john@example.com' }
+      const response = await request(app).post('/test').send(testData)
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(validatedDataFromRequest).toBeUndefined()
+    })
+
+    it('should handle validation errors correctly while still storing valid data', async () => {
+      // Arrange
+      const schemaValidator: ExpressYupMiddlewareInterface = {
+        schema: {
+          body: {
+            yupSchema: Yup.object().shape({
+              name: Yup.string().required(),
+              email: Yup.string().email().required(),
+            }),
+            validateOptions: {
+              abortEarly: false, // Don't abort after first error
+            },
+          },
+          query: {
+            yupSchema: Yup.object().shape({
+              filter: Yup.string().required(),
+            }),
+          },
+        },
+      }
+
+      let validatedDataFromRequest = null
+
+      const app = createAppWithPath({
+        path: '/test',
+        method: 'post',
+        middleware: expressYupMiddleware({
+          schemaValidator,
+          storeValidatedData: true,
+          continueOnError: true, // Continue despite errors
+        }),
+        handler: (req: Request, res: Response) => {
+          validatedDataFromRequest = req['validated']
+          return res.json({
+            validatedData: validatedDataFromRequest,
+            errors: req['validationErrors'],
+          })
+        },
+      })
+
+      // Act - Send invalid body but valid query
+      const invalidBodyData = { name: 'John Doe' } // Missing email
+      const response = await request(app).post('/test').query({ filter: 'active' }).send(invalidBodyData)
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(validatedDataFromRequest).toBeDefined()
+      expect(validatedDataFromRequest.query).toEqual({ filter: 'active' }) // Query should be validated
+      expect(validatedDataFromRequest.body).toBeUndefined() // Body should not be present due to validation error
+    })
+  })
+})


### PR DESCRIPTION
- Introduce `storeValidatedData` option to store validated and typed objects in the request
- Add `validatedDataKey` option to customize validated data storage location
- Update README with usage example for the new feature
- Enhance schema validator to support returning validated data
- Add comprehensive test coverage for validated data storage

This PR is related to issue #8